### PR TITLE
Allow users to move data from Axon Server to another

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - java-version: 8
-            sonar-enabled: false
-          - java-version: 11
+          - java-version: 17
             sonar-enabled: true
 
     steps:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1.4.3
@@ -33,7 +33,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Cache .m2
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Note: You can use environment variables in your properties, like so:
 ## Sources
 
 You should define the source of the events and snapshots you want to migrate. Currently, this can be an RDBMS database
-or a Mongo instance. The source is dermined by the `axoniq.migration.source` and can be configured with either `RDBMS`
-or `MONGO` currently. More information on specific properties for both can be found in the next sections.
+or a Mongo instance. The source is dermined by the `axoniq.migration.source` and can be configured with `RDBMS`, `MONGO`
+or `AXONSERVER`.
+More information on specific properties for both can be found in the next sections.
 
 ### RDBMS
 
@@ -69,26 +70,41 @@ In order to migrate from a Mongo database, the following properties should be su
 | `spring.data.mongodb.username` | Username of the database |
 | `spring.data.mongodb.password` | Password of the database |
 
-Other options for the Spring Mongo library can be used as well.
+### Axon Server
+
+You can use Axon Server as a source, to migrate events from one Axon Server to another.
+Note that snapshots won't be migrated, as Axon Server does not allow snapshots to be queried in this fashion.
+
+In order to migrate from an Axon Server, the following properties should be supplied:
+
+| Property                                     | Value                                                                    |
+|----------------------------------------------|--------------------------------------------------------------------------|
+| `axoniq.migration.source`                    | `AXONSERVER`                                                             |
+| `axoniq.migration.source.axonserver.servers` | Comma separated list of hostnames and ports for the Axon Server cluster. |
+| `axoniq.migration.source.axonserver.context` | The source context to migrate from, `default` by default.                |
+
+Note that you can use any Axon Server property under `axoniq.migration.source.axonserver` to configure the connection to the Axon Server,
+just like you would an Axon Framework application.
 
 ## Destinations
 
 We also need a place to store the events. The remote destination uses GRPC protocol to call Axon Server and store the events using the method also used by Axon
 Framework internally.
 
-### Remote
+### Axon Server
 
 In order to migrate events to Axon Server, define the following properties
 
-| Property                       | Value                                                                    |
-|--------------------------------|--------------------------------------------------------------------------|
-| `axoniq.migration.destination` | `AXONSERVER`                                                             |
-| `axoniq.axonserver.servers`    | Comma separated list of hostnames and ports for the Axon Server cluster. |
-| `axoniq.axonserver.context`    | The target context to migrate to, `default` by default.                  |
-| `axoniq.axonserver.token`      | The access token, if access control is enabled.                          |
+| Property                                          | Value                                                                    |
+|---------------------------------------------------|--------------------------------------------------------------------------|
+| `axoniq.migration.destination`                    | `AXONSERVER`                                                             |
+| `axoniq.migration.destination.axonserver.servers` | Comma separated list of hostnames and ports for the Axon Server cluster. |
+| `axoniq.migration.destination.axonserver.context` | The target context to migrate to, `default` by default.                  |
+| `axoniq.migration.destination.axonserver.token`   | The access token, if access control is enabled.                          |
 
-Any other Axon Framework properties for Axon Server can be used as well. This can be useful to configure certificates,
-access control tokens or other settings.
+
+Note that you can use any Axon Server property under `axoniq.migration.destination.axonserver` to configure the connection to the Axon Server,
+just like you would an Axon Framework application.
 
 ## Migrating tracking tokens
 

--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ just like you would an Axon Framework application.
 
 The migration tool only migrates the event store data to Axon Server. It does not update the tracking token values in
 token_entry tables. Tracking tokens are highly dependent on the implementation of the actual event store used.
-Migrating them is case specific and error-prone. Our recommendation is to reset the tracking processors after the
+Migrating them is case-specific and error-prone. Our recommendation is to reset the tracking processors after the
 migration.

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,9 @@
 
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 
-        <axon.version>4.6.8</axon.version>
+        <axon.version>4.10.2</axon.version>
         <h2.version>1.4.197</h2.version>
-        <spring-boot.version>2.7.1</spring-boot.version>
-        <grpc.version>1.50.3</grpc.version>
+        <spring-boot.version>3.4.4</spring-boot.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 
@@ -48,23 +47,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Defining grpc version is necessary, or maven will hang. Not sure why -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>${grpc.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.axonframework</groupId>
             <artifactId>axon-configuration</artifactId>
@@ -236,11 +226,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-site-plugin</artifactId>
-                        <version>3.7.1</version>
                     </plugin>
 
                     <plugin>

--- a/src/main/java/io/axoniq/axonserver/migration/MigrationBaseProperties.java
+++ b/src/main/java/io/axoniq/axonserver/migration/MigrationBaseProperties.java
@@ -50,12 +50,12 @@ public class MigrationBaseProperties {
 
     public enum MigrationSource {
         RDBMS,
-        MONGO
+        MONGO,
+        AXONSERVER,
     }
 
     public enum MigrationDestination {
-        REMOTE,
-        LOCAL
+        AXONSERVER
     }
 
     /**

--- a/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerConfiguration.java
@@ -1,0 +1,11 @@
+package io.axoniq.axonserver.migration.destination.remote;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "axoniq.migration.destination.axonserver")
+@Component("destinationAxonServerConfiguration")
+public class DestinationAxonServerConfiguration extends AxonServerConfiguration {
+
+}

--- a/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerEventStoreConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerEventStoreConfiguration.java
@@ -19,6 +19,7 @@ package io.axoniq.axonserver.migration.destination.remote;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -32,26 +33,21 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnProperty(value = "axoniq.migration.destination", havingValue = "AXONSERVER", matchIfMissing = true)
 @RequiredArgsConstructor
-public class RemoteEventStoreConfiguration {
+public class DestinationAxonServerEventStoreConfiguration {
     private final ApplicationContext applicationContext;
 
     @Bean
-    public AxonServerConfiguration axonServerConfiguration() {
-        AxonServerConfiguration configuration = new AxonServerConfiguration();
-        configuration.setComponentName(clientName(applicationContext.getId()));
-        return configuration;
+    public AxonServerConnectionManager axonServerConnectionManager(
+            @Qualifier("destinationAxonServerConfiguration") AxonServerConfiguration axonServerConfiguration) {
+        axonServerConfiguration.setComponentName(clientName(applicationContext.getId()));
+        return AxonServerConnectionManager.builder()
+                                          .axonServerConfiguration(axonServerConfiguration)
+                                          .build();
     }
 
     private String clientName(String id) {
         if( id == null) return "AxonServerMigration";
         if (id.contains(":")) return id.substring(0, id.indexOf(':'));
         return id;
-    }
-
-    @Bean
-    public AxonServerConnectionManager axonServerConnectionManager(AxonServerConfiguration axonServerConfiguration) {
-        return AxonServerConnectionManager.builder()
-                                          .axonServerConfiguration(axonServerConfiguration)
-                                          .build();
     }
 }

--- a/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerEventStoreConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/destination/remote/DestinationAxonServerEventStoreConfiguration.java
@@ -37,7 +37,7 @@ public class DestinationAxonServerEventStoreConfiguration {
     private final ApplicationContext applicationContext;
 
     @Bean
-    public AxonServerConnectionManager axonServerConnectionManager(
+    public AxonServerConnectionManager destinationAxonServerConnectionManager(
             @Qualifier("destinationAxonServerConfiguration") AxonServerConfiguration axonServerConfiguration) {
         axonServerConfiguration.setComponentName(clientName(applicationContext.getId()));
         return AxonServerConnectionManager.builder()

--- a/src/main/java/io/axoniq/axonserver/migration/destination/remote/RemoteEventStoreStrategy.java
+++ b/src/main/java/io/axoniq/axonserver/migration/destination/remote/RemoteEventStoreStrategy.java
@@ -21,8 +21,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.axoniq.axonserver.connector.event.EventStream;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.migration.destination.EventStoreStrategy;
-import lombok.RequiredArgsConstructor;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -32,12 +32,17 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-@RequiredArgsConstructor
 @Service
 @ConditionalOnProperty(value = "axoniq.migration.destination", havingValue = "AXONSERVER", matchIfMissing = true)
 public class RemoteEventStoreStrategy implements EventStoreStrategy {
 
     private final AxonServerConnectionManager axonServerConnectionManager;
+
+    public RemoteEventStoreStrategy(
+            @Qualifier("destinationAxonServerConnectionManager") AxonServerConnectionManager axonServerConnectionManager) {
+        this.axonServerConnectionManager = axonServerConnectionManager;
+    }
+
     private final Cache<String, Long> sequenceCache = Caffeine.newBuilder()
             .expireAfterAccess(Duration.of(1, ChronoUnit.MINUTES))
             .maximumSize(10000)

--- a/src/main/java/io/axoniq/axonserver/migration/migrators/db/MigrationDBConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/migrators/db/MigrationDBConfiguration.java
@@ -16,12 +16,13 @@
 
 package io.axoniq.axonserver.migration.migrators.db;
 
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
-import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -32,7 +33,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 /**
@@ -52,7 +52,7 @@ public class MigrationDBConfiguration {
             EntityManagerFactoryBuilder builder) {
         Map<String, String> properties = new HashMap<>();
         properties.put("hibernate.hbm2ddl.auto", "update");
-        properties.put("hibernate.physical_naming_strategy", SpringPhysicalNamingStrategy.class.getName());
+        properties.put("hibernate.physical_naming_strategy", CamelCaseToUnderscoresNamingStrategy.class.getName());
         properties.put("hibernate.implicit_naming_strategy", SpringImplicitNamingStrategy.class.getName());
         return builder
                 .dataSource(migrationDataSource())

--- a/src/main/java/io/axoniq/axonserver/migration/migrators/db/MigrationStatus.java
+++ b/src/main/java/io/axoniq/axonserver/migration/migrators/db/MigrationStatus.java
@@ -20,9 +20,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 /**
  * Entity representing the current status of the migration. Saved using an H2 database to allow the migration tool to

--- a/src/main/java/io/axoniq/axonserver/migration/source/MissingEventProducer.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/MissingEventProducer.java
@@ -21,7 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 /**
  * {@link EventStoreStrategy} that is used when the configuration is missing. Will throw an error on boot immediately.

--- a/src/main/java/io/axoniq/axonserver/migration/source/SnapshotEvent.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/SnapshotEvent.java
@@ -27,5 +27,4 @@ public interface SnapshotEvent extends BaseEvent {
     long getSequenceNumber();
 
     String getTimeStamp();
-
 }

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerBackedDomainEvent.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerBackedDomainEvent.java
@@ -2,13 +2,20 @@ package io.axoniq.axonserver.migration.source.axonserver;
 
 import io.axoniq.axonserver.grpc.event.EventWithToken;
 import io.axoniq.axonserver.migration.source.DomainEvent;
+import org.axonframework.axonserver.connector.util.GrpcMetaDataConverter;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Serializer;
 
 public class AxonServerBackedDomainEvent implements DomainEvent {
 
     private final EventWithToken eventWithToken;
+    private final Serializer serializer;
+    private final GrpcMetaDataConverter grpcMetaDataConverter;
 
-    public AxonServerBackedDomainEvent(EventWithToken eventWithToken) {
+    public AxonServerBackedDomainEvent(EventWithToken eventWithToken, Serializer serializer) {
         this.eventWithToken = eventWithToken;
+        this.serializer = serializer;
+        this.grpcMetaDataConverter = new GrpcMetaDataConverter(serializer);
     }
 
     @Override
@@ -58,6 +65,7 @@ public class AxonServerBackedDomainEvent implements DomainEvent {
 
     @Override
     public byte[] getMetaData() {
-        return eventWithToken.getEvent().getPayload().getData().toByteArray();
+        MetaData javaRepresentation = grpcMetaDataConverter.convert(eventWithToken.getEvent().getMetaDataMap());
+        return serializer.serialize(javaRepresentation, byte[].class).getData();
     }
 }

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerBackedDomainEvent.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerBackedDomainEvent.java
@@ -1,0 +1,63 @@
+package io.axoniq.axonserver.migration.source.axonserver;
+
+import io.axoniq.axonserver.grpc.event.EventWithToken;
+import io.axoniq.axonserver.migration.source.DomainEvent;
+
+public class AxonServerBackedDomainEvent implements DomainEvent {
+
+    private final EventWithToken eventWithToken;
+
+    public AxonServerBackedDomainEvent(EventWithToken eventWithToken) {
+        this.eventWithToken = eventWithToken;
+    }
+
+    @Override
+    public long getGlobalIndex() {
+        return eventWithToken.getToken();
+    }
+
+    @Override
+    public String getType() {
+        return eventWithToken.getEvent().getAggregateType();
+    }
+
+    @Override
+    public String getAggregateIdentifier() {
+        return eventWithToken.getEvent().getAggregateIdentifier();
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return eventWithToken.getEvent().getAggregateSequenceNumber();
+    }
+
+    @Override
+    public String getEventIdentifier() {
+        return eventWithToken.getEvent().getMessageIdentifier();
+    }
+
+    @Override
+    public long getTimeStampAsLong() {
+        return eventWithToken.getEvent().getTimestamp();
+    }
+
+    @Override
+    public String getPayloadType() {
+        return eventWithToken.getEvent().getPayload().getType();
+    }
+
+    @Override
+    public String getPayloadRevision() {
+        return eventWithToken.getEvent().getPayload().getRevision();
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return eventWithToken.getEvent().getPayload().getData().toByteArray();
+    }
+
+    @Override
+    public byte[] getMetaData() {
+        return eventWithToken.getEvent().getPayload().getData().toByteArray();
+    }
+}

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
@@ -22,6 +22,7 @@ import io.axoniq.axonserver.migration.source.EventProducer;
 import io.axoniq.axonserver.migration.source.SnapshotEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.serialization.Serializer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -40,12 +41,16 @@ import java.util.concurrent.TimeUnit;
 public class AxonServerEventProducer implements EventProducer {
 
     private final AxonServerConnectionManager connectionManager;
+    private final Serializer serializer;
     private EventStream eventStream;
     private Long lastRequestedEventToken = -1L;
 
     public AxonServerEventProducer(
-            @Qualifier("originAxonServerConnectionManager") AxonServerConnectionManager connectionManager) {
+            @Qualifier("originAxonServerConnectionManager") AxonServerConnectionManager connectionManager,
+            Serializer serializer
+    ) {
         this.connectionManager = connectionManager;
+        this.serializer = serializer;
     }
 
     @Override
@@ -70,7 +75,7 @@ public class AxonServerEventProducer implements EventProducer {
                     // No event available. Stop polling
                     break;
                 }
-                batch.add(new AxonServerBackedDomainEvent(eventWithToken));
+                batch.add(new AxonServerBackedDomainEvent(eventWithToken, serializer));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
@@ -70,7 +70,7 @@ public class AxonServerEventProducer implements EventProducer {
         List<AxonServerBackedDomainEvent> batch = new LinkedList<>();
         while (batch.size() < batchSize) {
             try {
-                EventWithToken eventWithToken = eventStream.nextIfAvailable(1, TimeUnit.SECONDS);
+                EventWithToken eventWithToken = eventStream.nextIfAvailable(30, TimeUnit.SECONDS);
                 if (eventWithToken == null) {
                     // No event available. Stop polling
                     break;

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/AxonServerEventProducer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2023. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.migration.source.axonserver;
+
+import io.axoniq.axonserver.connector.event.EventStream;
+import io.axoniq.axonserver.grpc.event.EventWithToken;
+import io.axoniq.axonserver.migration.source.EventProducer;
+import io.axoniq.axonserver.migration.source.SnapshotEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Produces events when defining the migration source as {@code AXONSERVER}.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(value = "axoniq.migration.source", havingValue = "AXONSERVER")
+public class AxonServerEventProducer implements EventProducer {
+
+    private final AxonServerConnectionManager connectionManager;
+    private EventStream eventStream;
+    private Long lastRequestedEventToken = -1L;
+
+    public AxonServerEventProducer(
+            @Qualifier("originAxonServerConnectionManager") AxonServerConnectionManager connectionManager) {
+        this.connectionManager = connectionManager;
+    }
+
+    @Override
+    public List<? extends AxonServerBackedDomainEvent> findEvents(long lastToken, int batchSize) {
+        if (lastToken < lastRequestedEventToken) {
+            // We need to reinitialize the stream
+            if (eventStream != null && !eventStream.isClosed()) {
+                eventStream.close();
+            }
+            eventStream = connectionManager.getConnection().eventChannel().openStream(lastToken, batchSize);
+        }
+        if (eventStream == null || eventStream.isClosed()) {
+            eventStream = connectionManager.getConnection().eventChannel().openStream(lastToken, batchSize);
+        }
+        lastRequestedEventToken = lastToken;
+
+        List<AxonServerBackedDomainEvent> batch = new LinkedList<>();
+        while (batch.size() < batchSize) {
+            try {
+                EventWithToken eventWithToken = eventStream.nextIfAvailable(1, TimeUnit.SECONDS);
+                if (eventWithToken == null) {
+                    // No event available. Stop polling
+                    break;
+                }
+                batch.add(new AxonServerBackedDomainEvent(eventWithToken));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return batch;
+    }
+
+    @Override
+    public List<? extends SnapshotEvent> findSnapshots(String lastProcessedTimestamp, int batchSize) {
+        // Unfortunately, not possible with Axon Server.
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/SourceAxonServerConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/SourceAxonServerConfiguration.java
@@ -1,0 +1,11 @@
+package io.axoniq.axonserver.migration.source.axonserver;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "axoniq.migration.source.axonserver")
+@Component("sourceAxonServerConfiguration")
+public class SourceAxonServerConfiguration extends AxonServerConfiguration {
+
+}

--- a/src/main/java/io/axoniq/axonserver/migration/source/axonserver/SourceAxonServerEventStoreConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/axonserver/SourceAxonServerEventStoreConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2023. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.migration.source.axonserver;
+
+import lombok.RequiredArgsConstructor;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that defines the correct beans to using a {@code AXONSERVER} origin.
+ *
+ * @author Mitchell Herrijgers
+ */
+@Configuration
+@ConditionalOnProperty(value = "axoniq.migration.source", havingValue = "AXONSERVER")
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SourceAxonServerConfiguration.class)
+public class SourceAxonServerEventStoreConfiguration {
+
+    private final ApplicationContext applicationContext;
+
+    @Bean(name = "originAxonServerConnectionManager")
+    public AxonServerConnectionManager axonServerConnectionManager(
+            @Qualifier("sourceAxonServerConfiguration") AxonServerConfiguration axonServerConfiguration) {
+        axonServerConfiguration.setComponentName(clientName(applicationContext.getId()));
+        return AxonServerConnectionManager.builder()
+                                          .axonServerConfiguration(axonServerConfiguration)
+                                          .build();
+    }
+
+    private String clientName(String id) {
+        if (id == null) {
+            return "AxonServerMigration";
+        }
+        if (id.contains(":")) {
+            return id.substring(0, id.indexOf(':'));
+        }
+        return id;
+    }
+}

--- a/src/main/java/io/axoniq/axonserver/migration/source/jpa/BaseEventEntry.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/jpa/BaseEventEntry.java
@@ -20,10 +20,10 @@ import io.axoniq.axonserver.migration.source.BaseEvent;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import javax.persistence.Basic;
-import javax.persistence.Column;
-import javax.persistence.Lob;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Lob;
+import jakarta.persistence.MappedSuperclass;
 
 /**
  * @author Marc Gathier

--- a/src/main/java/io/axoniq/axonserver/migration/source/jpa/DomainEventEntry.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/jpa/DomainEventEntry.java
@@ -18,13 +18,13 @@ package io.axoniq.axonserver.migration.source.jpa;
 
 import io.axoniq.axonserver.migration.source.DomainEvent;
 
-import javax.persistence.Basic;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
 
 /**
  * Entity representing an event in the RDBMS store.

--- a/src/main/java/io/axoniq/axonserver/migration/source/jpa/EventStoreDBConfiguration.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/jpa/EventStoreDBConfiguration.java
@@ -16,6 +16,7 @@
 
 package io.axoniq.axonserver.migration.source.jpa;
 
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,7 +24,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
-import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -34,7 +34,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 /**
@@ -54,7 +54,7 @@ public class EventStoreDBConfiguration {
             @Value("${axoniq.migration.disable-naming-strategy:false}") boolean disableNamingStrategy) {
         Map<String, Object> properties = new HashMap<>();
         if (!disableNamingStrategy) {
-            properties.put("hibernate.physical_naming_strategy", SpringPhysicalNamingStrategy.class.getName());
+            properties.put("hibernate.physical_naming_strategy", CamelCaseToUnderscoresNamingStrategy.class.getName());
             properties.put("hibernate.implicit_naming_strategy", SpringImplicitNamingStrategy.class.getName());
         }
 

--- a/src/main/java/io/axoniq/axonserver/migration/source/jpa/JpaEventProducer.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/jpa/JpaEventProducer.java
@@ -25,8 +25,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 /**
  * Produces events when defining the migration source as {@code RDBMS}. Queries the database using JPA to look up events

--- a/src/main/java/io/axoniq/axonserver/migration/source/jpa/SnapshotEventEntry.java
+++ b/src/main/java/io/axoniq/axonserver/migration/source/jpa/SnapshotEventEntry.java
@@ -20,10 +20,10 @@ import io.axoniq.axonserver.migration.source.SnapshotEvent;
 
 import java.io.Serializable;
 import java.util.Objects;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.NamedQuery;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.NamedQuery;
 
 /**
  * Entity representing a snapshot in the RDBMS store.


### PR DESCRIPTION
Allows users to define Axon Server as a source, so users can move events from one Axon Server instance to another, or from one context to another. 

To achieve this, we now expose Axon Server configuration under `axoniq.migration.source.axonserver.*` and `axoniq.migration.destination.axonserver.*`.

Snapshots are excluded from this migration possibility, because there is no reliable way to query snapshots in Axon Server this way. 